### PR TITLE
Bugfix - Firm name search

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -93,6 +93,7 @@ databases:
             left outer join name_variant as nv on nv.source_id == ei.entity_id
           where
             name like "%" || :name || "%"
+            or variantname like "%" || :name || "%"
           group by
             innovation_id
           order by

--- a/metadata.yml
+++ b/metadata.yml
@@ -83,14 +83,16 @@ databases:
             name_en,
             year,
             desc_sv,
-            group_concat(variantname) as firm_name
+            name as firm_name,
+            group_concat(variantname) as firm_name_variants
           from
             innovation as i
             join innovation_entity as ei on i.id == ei.innovation_id
             and ei.type == 1
-            join name_variant as nv on nv.source_id == ei.entity_id
+            join entity as e on e.id == ei.entity_id
+            left outer join name_variant as nv on nv.source_id == ei.entity_id
           where
-            variantname like "%" || :name || "%"
+            name like "%" || :name || "%"
           group by
             innovation_id
           order by


### PR DESCRIPTION
Fixes the search by Firm name -- examples:

[Atlas Copco](https://lite.datasette.io/?metadata=https://raw.githubusercontent.com/swinnoproject/datasette-lite/refs/heads/firm-names/metadata.yml&url=https://zenodo.org/api/records/13893763/files/SWINNO.UDIT.sqlite3/content#/content/Find%20innovation%20by%20firm%20name?name=Atlas+Copco)

[Rifa](https://lite.datasette.io/?metadata=https://raw.githubusercontent.com/swinnoproject/datasette-lite/refs/heads/firm-names/metadata.yml&url=https://zenodo.org/api/records/13893763/files/SWINNO.UDIT.sqlite3/content#/content/Find%20innovation%20by%20firm%20name?name=Rifa)

[Elementell](https://lite.datasette.io/?metadata=https://raw.githubusercontent.com/swinnoproject/datasette-lite/refs/heads/firm-names/metadata.yml&url=https://zenodo.org/api/records/13893763/files/SWINNO.UDIT.sqlite3/content#/content/Find%20innovation%20by%20firm%20name?name=Ellemtel)

[Spotify](https://lite.datasette.io/?metadata=https://raw.githubusercontent.com/swinnoproject/datasette-lite/refs/heads/firm-names/metadata.yml&url=https://zenodo.org/api/records/13893763/files/SWINNO.UDIT.sqlite3/content#/content/Find%20innovation%20by%20firm%20name?name=Spotify)

[Skype](https://lite.datasette.io/?metadata=https://raw.githubusercontent.com/swinnoproject/datasette-lite/refs/heads/firm-names/metadata.yml&url=https://zenodo.org/api/records/13893763/files/SWINNO.UDIT.sqlite3/content#/content/Find%20innovation%20by%20firm%20name?name=Skype)

